### PR TITLE
Add more integration tests on diff

### DIFF
--- a/src/diff.test.ts
+++ b/src/diff.test.ts
@@ -11,6 +11,18 @@ const testOnRepo = (commit1: string, commit2: string, expected: number): void =>
 };
 
 testOnRepo(
+  '79fc97d7a9dd644914e3942170b8fd5a4d7f27fb',
+  'caacb1aeb2be692fe8803ac91ca7c04493830fcd',
+  15
+);
+
+testOnRepo(
+  'caacb1aeb2be692fe8803ac91ca7c04493830fcd',
+  'ebdffbe230e3a98cc2383fe09c8fbb853e6784fd',
+  22
+);
+
+testOnRepo(
   'ebdffbe230e3a98cc2383fe09c8fbb853e6784fd',
   '26af977281bb05191206e477ddb4fbf80d9e750b',
   8


### PR DESCRIPTION
These tests are intended to show the old behavior of not special-casing moved lines. They are helpful to evaluate the impact of reducing count for moved lines in later diffs.